### PR TITLE
Adds GET /trips infinite loop to poll trip legs

### DIFF
--- a/components/App/App.test.js
+++ b/components/App/App.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import App from "./App";
+import App from "../../App";
 import { shallow, mount } from "enzyme";
 import renderer from "react-test-renderer";
 

--- a/components/PlaceCardWithLeg/PlaceCardWithLeg.js
+++ b/components/PlaceCardWithLeg/PlaceCardWithLeg.js
@@ -36,7 +36,6 @@ export default function PlacesCardWithLeg(props) {
         </TouchableOpacity>
       </ImageBackground>
       <View style={styles.legs}>
-        <Text style={styles.arrow}>{"\u2193"}</Text>
         <Text style={styles.distance}>{trip.legs[index].distance}</Text>
         <Text style={styles.hours}>
           {hoursToNextPlace(trip.legs[index].duration_in_hours)}

--- a/components/PlacesCard/PlacesCard.js
+++ b/components/PlacesCard/PlacesCard.js
@@ -11,11 +11,40 @@ import PlacesCardWithLeg from "../PlaceCardWithLeg/PlaceCardWithLeg";
 import PlaceCardWithoutLeg from "../PlaceCardWithoutLeg/PlaceCardWithoutLeg";
 
 export default class PlacesCard extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      checked: true
-    };
+  // constructor(props) {
+  //   super(props);
+  //   this.state = {
+  //     checked: true
+  //   };
+  // }
+  state = {
+    trip: this.props.navigation.getParam("trip", "Loading")
+  }
+
+  componentDidMount = () => {
+    this.checkTripStatus()
+  }
+
+  checkTripStatus = async () => {
+    // New fetch with GET, infinite loop until status 200
+    console.log("checkTripStatus invoked...")
+
+    try {
+      const response = await fetch(`http://localhost:3000/api/v1/trips?token=${this.state.trip.trip_token}`)
+      const updatedTrip = await response.json();
+      console.log("GET request status code: ", response.status)
+
+      if (response.status !== 200) {
+        setTimeout(() => {
+          this.checkTripStatus()
+        }, 5000) // 5 second wait between fetching again
+      } else {
+        this.setState({ trip: updatedTrip.data });
+      }
+
+    } catch (error) {
+      console.log(error.message);
+    }
   }
 
   hoursToNextPlace = hours => {
@@ -42,7 +71,7 @@ export default class PlacesCard extends Component {
 
   render() {
     const { navigation } = this.props;
-    const trip = navigation.getParam("trip", "loading");
+    const { trip } = this.state;
     return (
       <ImageBackground
         style={styles.backGround}

--- a/components/PlacesCard/PlacesCard.js
+++ b/components/PlacesCard/PlacesCard.js
@@ -37,7 +37,7 @@ export default class PlacesCard extends Component {
       if (response.status !== 200) {
         setTimeout(() => {
           this.checkTripStatus()
-        }, 5000) // 5 second wait between fetching again
+        }, 2500) // 5 second wait between fetching again
       } else {
         this.setState({ trip: updatedTrip.data });
       }
@@ -76,6 +76,7 @@ export default class PlacesCard extends Component {
       <ImageBackground
         style={styles.backGround}
         source={require("../../assets/roadtrip1.jpeg")}
+        imageStyle={{ opacity: 0.5 }}
       >
         <View style={styles.legend}>
           <Icon name="stop" size={30} color="green" />
@@ -169,7 +170,7 @@ export default class PlacesCard extends Component {
                 return (
                   <PlaceCardWithoutLeg
                     place={place}
-                    color={"yellow"}
+                    color={"green"}
                     weather={weather}
                     navigation={navigation}
                     key={place.id}


### PR DESCRIPTION
Co-authored-by: Theo Bean <beantheo@gmail.com>

Adds GET /trips infinite loop to poll trip legs
closes #36

- The PlacesCard now polls the `GET /api/v1/trips` with the trip_token provided from the response of `POST /api/v1/trips`
- It has a timeout set to 5 seconds between GET requests
- When the status code of the response is returned as 200, it renders the response with all the legs

Adds new issue #38
- Not sure why, but the miles are not rendering correctly.  Created an issue to address this

<img width="917" alt="Screen Shot 2019-07-24 at 6 12 46 PM" src="https://user-images.githubusercontent.com/36040194/61837127-9c9a2b00-ae40-11e9-9fde-a7de45838afb.png">
